### PR TITLE
Added TCP and UDP examples in Qt

### DIFF
--- a/tcp_example/tcp_client.cpp
+++ b/tcp_example/tcp_client.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <QCoreApplication>
+#include <QString>
+#include <QtNetwork>
+
+#define BUF_SIZE 1024
+
+int main(int argc, char *argv[])
+{
+    if (argc != 3) {
+        throw std::domain_error("Invalid number of arguments - expected ip address and port");
+    }
+
+    QCoreApplication a(argc, argv);
+
+    QString ipAddr = argv[1];
+    bool portOk = true;
+    quint16 port = QString(argv[2]).toUInt(&portOk);
+
+    if (port <= 0 || !portOk) {
+        throw std::domain_error("Invalid port");
+    }
+
+    QTcpSocket socket;
+    socket.connectToHost(ipAddr, port);
+    if(socket.waitForConnected() ) {
+        std::cout << "Connected to " << ipAddr.toStdString() << " port " << port << std::endl;
+    }
+
+    std::string data;
+    QByteArray data_srv;
+    std::cout << "Leave empty line to quit" << std::endl;
+    while(true) {
+        if(socket.isWritable()) {
+            std::cout << "Message to send: ";
+            std::getline(std::cin, data);
+            if (data == "") {
+                break;
+            }
+            socket.write(QString::fromStdString(data).toLatin1());
+        }
+
+        socket.waitForReadyRead(-1);
+        data_srv = socket.read(BUF_SIZE);
+        if (data_srv == "") {
+            break;
+        }
+        std::cout << "Answer: ";
+        std::cout << data_srv.constData() << std::endl;
+    }
+    socket.close();
+    std::cout << "Connection closed" << std::endl;
+
+
+    return a.exec();
+}

--- a/tcp_example/tcp_server.cpp
+++ b/tcp_example/tcp_server.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <QCoreApplication>
+#include <QString>
+#include <QtNetwork>
+
+#define BUF_SIZE 1024
+QTcpServer server;
+
+void handleConnection()
+{
+    QTcpSocket* socket = server.nextPendingConnection();
+
+    if (!socket) {
+        return;
+    }
+
+    std::cout << "Client connected " << socket->peerAddress().toString().toStdString() << std::endl;
+
+    while (true) {
+        socket->waitForReadyRead(-1);
+        QByteArray data = socket->read(BUF_SIZE);
+        if (data.isNull()) {
+            socket->close();
+            std::cout << "No message" << std::endl;
+            break;
+        }
+
+        std::cout << "Message: " << data.constData() << std::endl;
+        socket->write(data);
+    }
+    socket->close();
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        throw std::domain_error("Invalid number of arguments - expected port");
+    }
+
+    QCoreApplication a(argc, argv);
+
+    bool portOk = true;
+    quint16 port = QString(argv[1]).toUInt(&portOk);
+
+    if (port <= 0 || !portOk) {
+        throw std::domain_error("Invalid port");
+    }
+
+    server.setMaxPendingConnections(5);
+
+    QHostAddress ipAddr;
+    ipAddr.setAddress("127.0.0.1");
+
+    std::cout << "Listening on port " << port << " ..." << std::endl;
+
+    if(!server.listen(ipAddr, port)) {
+        throw std::domain_error("Listening error");
+    }
+
+    QObject::connect(&server, &QTcpServer::newConnection, handleConnection);
+
+
+    return a.exec();
+}

--- a/udp_example/udp_client.cpp
+++ b/udp_example/udp_client.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <QCoreApplication>
+#include <QString>
+#include <QtNetwork>
+
+#define BUF_SIZE 1024
+
+int main(int argc, char *argv[])
+{
+    if (argc != 3) {
+        throw std::domain_error("Invalid number of arguments - expected ip address and port");
+    }
+
+    QCoreApplication a(argc, argv);
+
+    QString ipAddr = argv[1];
+    bool portOk = true;
+    quint16 port = QString(argv[2]).toUInt(&portOk);
+
+    if (port <= 0 || !portOk) {
+        throw std::domain_error("Invalid port");
+    }
+
+    QUdpSocket socket;
+    QHostAddress host;
+    host.setAddress(ipAddr);
+
+    std::string data;
+    QByteArray data_srv;
+    std::cout << "Leave empty line to quit" << std::endl;
+    while(true) {
+        std::cout << "Message to send: ";
+        std::getline(std::cin, data);
+        if (data == "") {
+            break;
+        }
+        socket.writeDatagram(QString::fromStdString(data).toLatin1(), host, port);
+        try {
+           QNetworkDatagram datagram = socket.receiveDatagram();
+           QByteArray data(datagram.data(), BUF_SIZE);
+           if (data.isNull()) {
+               break;
+           }
+           std::cout << "Answer: ";
+           std::cout << data.constData() << std::endl;
+        } catch (...) {
+            std::cout << "Could not get any response";
+        }
+    }
+    socket.close();
+    std::cout << "Connection closed" << std::endl;
+
+
+    return a.exec();
+}

--- a/udp_example/udp_server.cpp
+++ b/udp_example/udp_server.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <QCoreApplication>
+#include <QString>
+#include <QtNetwork>
+
+#define BUF_SIZE 1024
+QUdpSocket socket;
+
+void handleConnection()
+{
+    while (true) {
+        if (socket.hasPendingDatagrams()) {
+           QNetworkDatagram datagram = socket.receiveDatagram();
+           QByteArray data(datagram.data(), BUF_SIZE);
+           if (data.isNull()) {
+               socket.close();
+               std::cout << "No message" << std::endl;
+               break;
+           }
+           std::cout << "Message: " << data.constData() << std::endl;
+           socket.writeDatagram(datagram.makeReply(data));
+        }
+    }
+    socket.close();
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc != 2) {
+        throw std::domain_error("Invalid number of arguments - expected port");
+    }
+
+    QCoreApplication a(argc, argv);
+
+    bool portOk = true;
+    quint16 port = QString(argv[1]).toUInt(&portOk);
+
+    if (port <= 0 || !portOk) {
+        throw std::domain_error("Invalid port");
+    }
+
+    QHostAddress ipAddr;
+    ipAddr.setAddress("127.0.0.1");
+
+    socket.bind(ipAddr, port);
+    std::cout << "Listening on port " << port << " ..." << std::endl;
+
+    QObject::connect(&socket, &QUdpSocket::readyRead, handleConnection);
+
+    return a.exec();
+}


### PR DESCRIPTION
Writing a network project in Qt requires adding "QT += network" in a .pro file. 